### PR TITLE
Update labels in OrderResource and History components for consistency

### DIFF
--- a/app/Filament/Resources/OrderResource.php
+++ b/app/Filament/Resources/OrderResource.php
@@ -243,7 +243,7 @@ class OrderResource extends Resource
                 ActionGroup::make([
                     EditAction::make(),
                     Action::make('list_pdf')
-                        ->label('Перечень PDF')
+                        ->label('Спецификация')
                         ->url(fn (Order $record) => route('orders.list_pdf', $record->id))
                         ->openUrlInNewTab()
                         ->icon('heroicon-o-arrow-down-tray'),

--- a/resources/js/Pages/App/History.vue
+++ b/resources/js/Pages/App/History.vue
@@ -119,11 +119,11 @@ const deleteOrder = (order_id: number) => {
 								            </DropdownMenuItem>
 								            <DropdownMenuItem @click="downloadListPDF(order.id)">
 								                    <ScrollTextIcon class="size-4" />
-								                    <span>Перечень PDF</span>
+								                    <span>Спецификация</span>
 								            </DropdownMenuItem>
 								            <DropdownMenuItem>
 								                    <ReceiptRussianRubleIcon class="size-4" />
-								                    <span>Счет PDF</span>
+								                    <span>Счет</span>
 								            </DropdownMenuItem>
 								            <DropdownMenuItem @click="visitSketcherPage(order.id)">
 								                <DraftingCompassIcon class="size-4" />

--- a/resources/js/Stores/sketcherStore.ts
+++ b/resources/js/Stores/sketcherStore.ts
@@ -206,7 +206,7 @@ export const useSketcherStore = defineStore('sketcherStore', () => {
 	const getOpeningSketchDimensions = (doorIndex: number) => {
 		if (!currentOpening.value) return { width: 0, height: 0 };
 
-		let gap = currentOpening.value.type == "center" ? sketch_vars.value[selectedOpeningID.value].a[0] + sketch_vars.value[selectedOpeningID.value].b[0] + sketch_vars.value[selectedOpeningID.value].e[0] + sketch_vars.value[selectedOpeningID.value].g[0] + 3 : 130;
+		let gap = currentOpening.value.type == "center" ? sketch_vars.value[selectedOpeningID.value].a[0] + sketch_vars.value[selectedOpeningID.value].b[0] + sketch_vars.value[selectedOpeningID.value].e[0] + sketch_vars.value[selectedOpeningID.value].g[0] + 3 : 2 * sketch_vars.value[selectedOpeningID.value].a[0] + sketch_vars.value[selectedOpeningID.value].b[0] + sketch_vars.value[selectedOpeningID.value].e[0] + sketch_vars.value[selectedOpeningID.value].g[0];
 		let doorsGap = {
 			start: sketch_vars.value[selectedOpeningID.value].e[0] + sketch_vars.value[selectedOpeningID.value].g[0],
 			end: sketch_vars.value[selectedOpeningID.value].b[0],


### PR DESCRIPTION
- Changed label 'Перечень PDF' to 'Спецификация' in OrderResource and History.vue for improved clarity.
- Updated 'Счет PDF' to 'Счет' in History.vue to streamline terminology.
- Adjusted gap calculation logic in sketcherStore for accurate dimension handling based on opening type.