### PR TITLE
Add simple list PDF generation from calculator in OrderController

### DIFF
--- a/resources/js/Components/Calculator/OrderActions.vue
+++ b/resources/js/Components/Calculator/OrderActions.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ArrowRightIcon, BadgePercentIcon, EllipsisVertical, FilePenIcon, Printer, Ruler, ScrollText } from "lucide-vue-next"
+import { ArrowRightIcon, BadgePercentIcon, EllipsisVertical, FilePenIcon, FileText, Printer, Ruler, ScrollText } from "lucide-vue-next"
 import Button from "../ui/button/Button.vue"
 import DropdownMenu from "../ui/dropdown-menu/DropdownMenu.vue"
 import DropdownMenuTrigger from "../ui/dropdown-menu/DropdownMenuTrigger.vue"
@@ -95,7 +95,7 @@ const downloadCommercialOffer = async () => {
     }
 }
 
-const downloadListPDF = async () => {
+const downloadSpecificationPDF = async () => {
     try {
         toast.info("Подготовка спецификации...")
         const formData = {
@@ -117,7 +117,7 @@ const downloadListPDF = async () => {
         const link = document.createElement('a')
     
         link.href = url
-        link.setAttribute('download', `list_${new Date().toISOString().split('T')[0]}.pdf`)
+        link.setAttribute('download', `specification_${new Date().toISOString().split('T')[0]}.pdf`)
         document.body.appendChild(link)
         link.click()
         
@@ -126,6 +126,40 @@ const downloadListPDF = async () => {
     } catch (error) {
         console.error('Error downloading the PDF:', error)
         toast.error("Ошибка при загрузке спецификации")
+    }
+}
+
+const downloadListPDF = async () => {
+    try {
+        toast.info("Подготовка перечня...")
+        const formData = {
+            name: order_info.value.name,
+            phone: order_info.value.phone,
+            address: order_info.value.address,
+            email: order_info.value.email,
+            cart_items: itemsStore.cartItems,
+            openings: openingsStore.openings,
+            total_price: itemsStore.total_price.with_discount,
+        }
+    
+        const response = await axios.post('/orders/simple-list-from-calc', formData, {
+            responseType: 'blob', 
+            headers: { 'Content-Type': 'application/json' }
+        })
+    
+        const url = window.URL.createObjectURL(new Blob([response.data]))
+        const link = document.createElement('a')
+    
+        link.href = url
+        link.setAttribute('download', `list_${new Date().toISOString().split('T')[0]}.pdf`)
+        document.body.appendChild(link)
+        link.click()
+        
+        link.parentNode?.removeChild(link)
+        toast.success("Перечень успешно загружен")
+    } catch (error) {
+        console.error('Error downloading the PDF:', error)
+        toast.error("Ошибка при загрузке перечня")
     }
 }
 </script>
@@ -156,9 +190,13 @@ const downloadListPDF = async () => {
                             <Printer class="size-4 mr-2" />
                             <span>Печать КП</span>
                         </DropdownMenuItem>
-                        <DropdownMenuItem @click="downloadListPDF" class="cursor-pointer">
+                        <DropdownMenuItem @click="downloadSpecificationPDF" class="cursor-pointer">
                             <ScrollText class="size-4 mr-2" />
                             <span>Спецификация</span>
+                        </DropdownMenuItem>
+                        <DropdownMenuItem @click="downloadListPDF" class="cursor-pointer">
+                            <FileText class="size-4 mr-2" />
+                            <span>Перечень</span>
                         </DropdownMenuItem>
                                                 
                         <DropdownMenuSub v-if="can_access_wholesale_factors">

--- a/resources/views/orders/list_pdf.blade.php
+++ b/resources/views/orders/list_pdf.blade.php
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Перечень</title>
+    <style>
+        body {
+            font-family: DejaVu Sans, sans-serif;
+            margin: -16px;
+            padding: 0;
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 20px;
+        }
+        .header h1 {
+            margin: 0;
+        }
+        .table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 20px;
+        }
+        .table th, .table td {
+            border: 1px solid #ddd;
+            padding: 4px;
+            text-align: left;
+            text-align: center;
+        }
+        .table th {
+            background-color: #f2f2f2;
+        }
+        .nowrap {
+            white-space: nowrap;
+        }
+        .footer {
+            text-align: center;
+            margin-top: 20px;
+        }
+        * {
+            font-size: 12px !important;
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        @if ($order->order_number)
+            <h1>Заказ №{{ $order->order_number }}</h1>
+        @else
+            <h1>Перечень</h1>
+        @endif
+    </div>
+
+    <table style="width: 100%">
+        <tbody>
+            <tr>
+                <td><b>Ф.И.О.:</b> {{ $order->customer_name }}</td>
+                <td><b>Телефон:</b> {{ $order->customer_phone }}</td>
+            </tr>
+            <tr>
+                <td><b>Почта:</b> {{ $order->customer_email }}</td>
+                <td><b>Адрес:</b> {{ $order->customer_address }}</td>
+            </tr>
+            <tr>
+                <td><b>Комментарий к заказу:</b> {{ $order->comment ?? '-' }}</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h2>Проемы</h2>
+    @if($orderOpenings)
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Тип проема</th>
+                    <th>Кол-во створок</th>
+                    <th>Ш х В, мм</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($orderOpenings as $opening)
+                    <tr>
+                        <td style="text-align: left !important;">
+                            @switch($opening->type)
+                                @case('left')
+                                    Левый проем
+                                    @break
+                                @case('right')
+                                    Правый проем
+                                    @break
+                                @case('center')
+                                    Центральный проем
+                                    @break
+                                @case('inner-left')
+                                    Входная группа левая
+                                    @break
+                                @case('inner-right')
+                                    Входная группа правая
+                                    @break
+                                @case('blind-glazing')
+                                    Глухое остекление
+                                    @break
+                                @case('triangle')
+                                    Треугольник
+                                    @break
+                                @default
+                                    {{ $opening->type }}
+                            @endswitch
+                        </td>
+                        <td>{{ $opening->type != 'blind-glazing' && $opening->type != 'triangle' ? $opening->doors . ' ств.' : '-' }}</td>
+                        <td>{{ $opening->width }} x {{ $opening->height }}</td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    @endif
+
+    <h2>Детали</h2>
+    <table class="table">
+        <thead>
+            <tr>
+                <th class="nowrap">№</th>
+                <th class="nowrap">Картинка</th>
+                <th class="nowrap">Деталь</th>
+                <th class="nowrap">Кол-во</th>
+            </tr>
+        </thead>
+        <tbody>
+            @php
+                $count = 0;
+            @endphp
+            @foreach($orderItems as $item)
+                <tr>
+                    <td class="nowrap">{{ ++$count }}</td>
+                    <td class="nowrap">
+                        @if ($item->item->img != null)
+                            <img src="data:image/jpeg;base64,{{ base64_encode(file_get_contents(base_path('public/storage' . ($item->item->img[0] != '/' ? '/' : '') . $item->item->img))) }}" alt="" width="48">
+                        @endif
+                    </td>
+                    <td class="" style="text-align:left !important;">{{ $item->item->name . ($item->item->vendor_code ? ' - ' . $item->item->vendor_code : '') }}</td>
+                    <td class="nowrap">{{  number_format((float)$item->quantity, 2, '.', '') }} {{ $item->item->unit }}</td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -185,6 +185,8 @@ Route::get('/orders/{orderId}/list-pdf', [OrderController::class, 'listPDF'])
     ->name('orders.list_pdf');
 Route::post('/orders/list-pdf-from-calc', [OrderController::class, 'listFromCalcPDF'])
     ->name('orders.calc_list_pdf');
+Route::post('/orders/simple-list-from-calc', [OrderController::class, 'simpleListFromCalcPDF'])
+    ->name('orders.simple_list_from_calc');
 Route::post('/orders/commercial-offer', [OrderController::class, 'commercialOfferPDF'])
     ->name('orders.commercial_offer_pdf');
 Route::post('/orders/sketch', [OrderController::class, 'sketchPDF'])


### PR DESCRIPTION
- Introduced a new method `simpleListFromCalcPDF` in OrderController to generate and download a simple list PDF for temporary orders.
- Added validation for order fields and mapped cart items and openings for PDF generation.
- Updated OrderActions.vue to include a new function for downloading the simple list PDF and modified existing function names for clarity.
- Added a new route for the simple list PDF generation in web.php.