### PR TITLE
Restrict login access to super admins during maintenance

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -30,8 +30,15 @@ class AuthenticatedSessionController extends Controller
     public function store(LoginRequest $request): RedirectResponse
     {
         $request->authenticate();
-
         $request->session()->regenerate();
+
+        // Block all users except super admins
+        if (!Auth::user()->hasRole('Super-Admin')) {
+            Auth::logout();
+            return redirect()->route('login')->withErrors([
+                'email' => 'Технические работы до пятницы 11-го. Вход временно доступен только для супер-админов.'
+            ]);
+        }
 
         // return redirect()->intended(route('dashboard', absolute: false));
         return redirect()->route('app.home');

--- a/resources/js/Pages/Auth/Index.vue
+++ b/resources/js/Pages/Auth/Index.vue
@@ -16,6 +16,7 @@ const form = useForm({
 			<div class="mx-auto grid w-[350px] gap-6">
 				<div class="grid gap-2 text-center">
 					<h1 class="text-3xl font-bold">Вход</h1>
+					<p class="text-red-600 font-semibold">Технические работы до пятницы 11-го. Вход временно доступен только для супер-админов.</p>
 					<p class="text-balance text-muted-foreground">Добро пожаловать снова!</p>
 				</div>
 				<div class="grid gap-4">


### PR DESCRIPTION
- Updated the AuthenticatedSessionController to log out users who do not have the 'Super-Admin' role, displaying a maintenance message.
- Added a corresponding message in the Index.vue login page to inform users about the restricted access during technical work.