### PR TITLE
Implement generateDXF method in SketchController for DXF file generation

### DIFF
--- a/resources/js/Stores/sketcherStore.ts
+++ b/resources/js/Stores/sketcherStore.ts
@@ -381,6 +381,7 @@ export const useSketcherStore = defineStore('sketcherStore', () => {
 				{
 					openings: combinedOpenings.value,
 					saveData: false,
+					order_id: order.value.id,
 				},
 				{
 					responseType: "blob",


### PR DESCRIPTION
- Added a new method to handle DXF file generation based on request data, including validation for openings and order_id.
- Enhanced order opening processing by reversing the order and calculating coordinates for sketch generation.
- Integrated logging for debugging hole coordinate calculations.
- Updated sketcherStore to include order_id in the request payload for DXF generation.