### PR TITLE
Update contact information in GuestFooter and Partners pages

### DIFF
--- a/resources/js/Layouts/GuestFooter.vue
+++ b/resources/js/Layouts/GuestFooter.vue
@@ -72,8 +72,8 @@ const socialLinks = ref([
 					<h3 class="text-lg font-semibold mb-4 text-light-gold">Контакты</h3>
 					<div class="space-y-2 text-gray-300">
 						<p>{{ getOption('ui_address', 'г. Краснодар') }}</p>
-						<a :href="`tel:${getOption('phone', '+7 993 993-29-98')}`" class="block hover:text-light-gold transition-colors"> 
-							{{ getOption('phone_formatted', '+7 (993) 993-29-98') }}
+						<a :href="`tel:${getOption('phone', '+7 952 869-53-36')}`" class="block hover:text-light-gold transition-colors"> 
+							{{ getOption('phone_formatted', '+7 (952) 869-53-36') }}
 						</a>
 						<a :href="`mailto:${getOption('email', 'info@llymar.ru')}`" class="block hover:text-light-gold transition-colors"> 
 							{{ getOption('email', 'info@llymar.ru') }}

--- a/resources/js/Pages/Partners.vue
+++ b/resources/js/Pages/Partners.vue
@@ -20,8 +20,8 @@ import {
 } from "lucide-vue-next";
 import { vMaska } from "maska/vue";
 
-const PARTNERS_PHONE = "+79528695336";
-const PARTNERS_PHONE_FORMATTED = "+7 (952) 869-53-36";
+const PARTNERS_PHONE = "+79939932998";
+const PARTNERS_PHONE_FORMATTED = "+7 (993) 993-29-98";
 const PAGE_SOURCE = "Страница «Специалистам»";
 
 const partnerTypes = [


### PR DESCRIPTION
- Changed phone number references in GuestFooter.vue and Partners.vue to the new contact number +7 (952) 869-53-36 for consistency across the application.